### PR TITLE
changed all the error messages to JP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 
 gem 'payjp'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6)
       actionpack (= 6.0.6)
       activesupport (= 6.0.6)
@@ -331,6 +334,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/app/models/order_destination.rb
+++ b/app/models/order_destination.rb
@@ -9,14 +9,14 @@ class OrderDestination
     validates :city
     validates :block
 
-    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'is invalid.' }
+    validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'が無効です。' }
 
-    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'is invalid. Enter it as follows (e.g. 123-4567)' }
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'が無効です。次のように入力してください (例 123-4567)' }
 
     validates :token
   end
 
-  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "を選択してください" }
 
   validate :building
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,16 +13,16 @@ class User < ApplicationRecord
   end
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: 'is invalid. Include both letters and numbers'
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'は無効です。文字と数字を入力してください。'
 
   with_options presence: true,
-               format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters' } do
+               format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'は無効です。全角文字を入力してください。' } do
     validates :first_name
     validates :last_name
   end
 
   with_options presence: true,
-               format: { with: /\A[ァ-ヶ一]+\z/, message: 'is invalid. Input full-width katakana characters' } do
+               format: { with: /\A[ァ-ヶ一]+\z/, message: 'は無効です。全角カタカナ文字を入力してください。' } do
     validates :last_name_kana
     validates :first_name_kana
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,12 @@ module Furima38725
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
+
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        birthday: 生年月日
+        first_name: お名前
+        last_name: 名字
+        last_name_kana: 名字（カタカナ）
+        first_name_kana: お名前（カタカナ）
+
+  activemodel:
+    attributes:
+      order_destination:
+        city: 市区町村
+        postal_code: 郵便番号
+        phone_number: 電話番号
+        prefecture_id: 都道府県
+        block: 番地
+        building: 建物名    

--- a/spec/models/order_destination_spec.rb
+++ b/spec/models/order_destination_spec.rb
@@ -22,63 +22,62 @@ RSpec.describe OrderDestination, type: :model do
       it 'credit card info が空だと保存できないこと' do
         @order_destination.token = nil
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Token can't be blank")
+        expect(@order_destination.errors.full_messages).to include("Tokenを入力してください")
       end
       it 'postal_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
         @order_destination.postal_code = '1234567'
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include('Postal code is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_destination.errors.full_messages).to include('郵便番号が無効です。次のように入力してください (例 123-4567)')
       end
       it 'postal_codeがblankだと保存できない' do
         @order_destination.postal_code = ''
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Postal code can't be blank")
+        expect(@order_destination.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'phone number が空だと保存できない' do
         @order_destination.phone_number = ''
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order_destination.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phone number が数字以外では保存できない' do
         @order_destination.phone_number = 'asdfghj'
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Phone number is invalid.")
+        expect(@order_destination.errors.full_messages).to include("電話番号が無効です。")
       end 
       it 'phone numberが9桁以下では購入できない' do
         @order_destination.phone_number = '0804647'
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include('Phone number is invalid.')
+        expect(@order_destination.errors.full_messages).to include('電話番号が無効です。')
       end
       it 'phone numberが12桁以上では購入できない' do
         @order_destination.phone_number = '08046472222222'
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include('Phone number is invalid.')
+        expect(@order_destination.errors.full_messages).to include('電話番号が無効です。')
       end
       it 'cityが空だと保存できない' do
         @order_destination.city = ''
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("City can't be blank")
+        expect(@order_destination.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'prefectureを選択しないと保存できない' do
         @order_destination.prefecture_id = 1
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_destination.errors.full_messages).to include("都道府県を選択してください")
       end
       it 'blockが空だと保存できない' do
         @order_destination.block = ''
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Block can't be blank")
+        expect(@order_destination.errors.full_messages).to include("番地を入力してください")
       end
       it 'userが紐付いていないと保存できないこと' do
         @order_destination.user_id = nil
         @order_destination.valid?
-
-        expect(@order_destination.errors.full_messages).to include("User can't be blank")
+        expect(@order_destination.errors.full_messages).to include("Userを入力してください")
       end
       it 'itemが紐付いていないと保存できないこと' do
         @order_destination.item_id = nil
         @order_destination.valid?
-        expect(@order_destination.errors.full_messages).to include("Item can't be blank")
+        expect(@order_destination.errors.full_messages).to include("Itemを入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,140 +15,140 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it 'emailは@を含まないと登録できない' do
         @user.email = 'testgmail'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
       it '重複したemailが存在する場合は登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password = 'bizcliz4life'
         @user.password_confirmation = 'bizcliz5life'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = 'bc4lf'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
       it 'passwordに数字がない場合' do
         @user.password = 'bizclizzlife'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは無効です。文字と数字を入力してください。')
       end
       it 'passwordに英文字がない場合' do
         @user.password = '1234567'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは無効です。文字と数字を入力してください。')
       end
       it '半角英数字ではない場合' do
         @user.password = 'kkkk２２２'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは無効です。文字と数字を入力してください。')
       end
       it 'first nameがない場合' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("お名前を入力してください")
       end
       it 'first nameが全角じゃない場合(english)' do
         @user.first_name = 'Thomas'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('お名前は無効です。全角文字を入力してください。')
       end
       it 'first nameに数字がある場合' do
         @user.first_name = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('お名前は無効です。全角文字を入力してください。')
       end
       it 'last nameがない場合' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("名字を入力してください")
       end
       it 'last nameが全角じゃない場合(english)' do
         @user.last_name = 'Thomas'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('名字は無効です。全角文字を入力してください。')
       end
       it 'last nameに数字がある場合' do
         @user.last_name = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('名字は無効です。全角文字を入力してください。')
       end
       it 'first name kana がない場合' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("お名前（カタカナ）を入力してください")
       end
       it 'first name kana が平仮名の場合' do
         @user.first_name_kana = 'りょう'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('お名前（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'first name kana が漢字の場合' do
         @user.first_name_kana = '量'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('お名前（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'first name kana がengの場合' do
         @user.first_name_kana = 'thomas'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('お名前（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'first name kana が数字の場合' do
         @user.first_name_kana = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('お名前（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'last name kana がない場合' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名字（カタカナ）を入力してください")
       end
       it 'last name kana が平仮名の場合' do
         @user.last_name_kana = 'りょう'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名字（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'last name kana が漢字の場合' do
         @user.last_name_kana = '量'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名字（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'Last name kana がengの場合' do
         @user.last_name_kana = 'thomas'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名字（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'first name kana が数字の場合' do
         @user.last_name_kana = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid. Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名字（カタカナ）は無効です。全角カタカナ文字を入力してください。')
       end
       it 'birthdayがない場合' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-I18n.locale = 'en'
+I18n.locale = 'ja'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
# WHAT
changed all the error messages to JP

# WHY

Since all the functions and options in the app are in JP, it can be speculated that the primary users of the app are in Japan, and thus all error messages should be changed to Japanese for convenience. 